### PR TITLE
supports adding read permissions on applications.  Ref #614.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Parameter | Description | Usage
 
 To create or update permissions on an application:
 
-    $ cloco application permissions create --sub subscription_identifier --app application_identifier --username username
+    $ cloco application permissions create --sub subscription_identifier --app application_identifier --username username [--admin|--read]
 
 ### Parameters
 
@@ -237,6 +237,7 @@ Parameter | Description | Usage
 --sub | The ID of the subscription. | Optional if defaulted via the cloco init command.
 --app | The ID of the application. | Optional if defaulted via the cloco init command.
 --username | The username to permission. | Required. The username in cloco.
+--admin / --read | Flag. | The permission level to assign.  Defaults to 'read'.
 
 ## Revoke Application Permissions
 

--- a/cloco_cli/cli.py
+++ b/cloco_cli/cli.py
@@ -377,7 +377,9 @@ def list_application_permissions(sub, app):
 @click.option('--sub', help='The subscription identifier, will use the subscription stored in the preferences if not supplied', default='')
 @click.option('--app', help='The application identifier, will use the application stored in preferences if not supplied', default='')
 @click.option('--username', help='The username to be added to the subscription')
-def create_application_permission(sub, app, username):
+@click.option('--admin', 'role', flag_value='admin', help='The user role (admin | read)')
+@click.option('--read', 'role', flag_value='read', help='The user role (admin | read)', default=True)
+def create_application_permission(sub, app, username, role):
     """Creates or modifies permissions in an application."""
     config = load_config()
     authenticate(config)
@@ -387,7 +389,7 @@ def create_application_permission(sub, app, username):
         app = config['preferences']['application']
     u = '{0}/{1}/applications/{2}/permissions'.format(
         get_url(config), sub, app)
-    body = {'permissionLevel': 'admin', 'identity': username}
+    body = {'permissionLevel': role, 'identity': username}
     r = requests.post(u, data=json.dumps(body), headers=get_headers(config))
     print_response(r)
     return

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,16 @@
+# Clears the dist folder
+echo "Clearing the dist folder"
+rm -rf dist/*
+
+# Build the wheel
+echo "Building the wheel package"
+python setup.py bdist_wheel --universal
+
+# Register
+WHEEL="dist/$(ls dist)"
+echo "Registering package $WHEEL"
+twine register $WHEEL
+
+# Upload
+echo "Uploading package $WHEEL"
+twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,13 @@ dependencies = ['click', 'requests', 'configparser']
 
 setup(
     name='cloco-cli',
-    version='0.1.6',
+    version='0.1.7',
     license='BSD',
     author='345 Systems',
     author_email='info@345.systems',
     description='A command line interface for the cloco API.',
     url='https://github.com/cloudconfig/cloco-cli',
-    download_url='https://github.com/cloudconfig/cloco-cli/tarball/0.1.6',
+    download_url='https://github.com/cloudconfig/cloco-cli/tarball/0.1.7',
     keywords=['cloco', 'cloudconfig', 'configuration',
               'configuration-as-a-service', 'devops'],
     long_description=__doc__,


### PR DESCRIPTION
CLI allows the permission level on the application to be set to read|admin.
Also includes a deploy script for twine.